### PR TITLE
rft - use commons-lang3 to format duration with words instead of millis

### DIFF
--- a/matcher-decorators/src/main/java/ru/yandex/qatools/matchers/decorators/TimeoutWaiter.java
+++ b/matcher-decorators/src/main/java/ru/yandex/qatools/matchers/decorators/TimeoutWaiter.java
@@ -3,6 +3,7 @@ package ru.yandex.qatools.matchers.decorators;
 import org.hamcrest.Description;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
 
 /**
  * @author Alexander Tolmachev starlight@yandex-team.ru
@@ -38,6 +39,6 @@ public class TimeoutWaiter extends Waiter {
 
     @Override
     public void describeTo(Description description) {
-        description.appendValue(timeout).appendText(" milliseconds");
+        description.appendText(formatDurationWords(timeout, true, true));
     }
 }

--- a/matcher-decorators/src/test/java/ru/yandex/qatools/matchers/decorators/TimeoutWaiterTest.java
+++ b/matcher-decorators/src/test/java/ru/yandex/qatools/matchers/decorators/TimeoutWaiterTest.java
@@ -1,0 +1,33 @@
+package ru.yandex.qatools.matchers.decorators;
+
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * User: lanwen
+ * Date: 30.09.14
+ * Time: 17:52
+ */
+public class TimeoutWaiterTest {
+
+    @Test
+    public void shouldReturn30SecondsDescriptionByDefault() throws Exception {
+        StringDescription description = new StringDescription();
+        TimeoutWaiter.timeoutHasExpired().describeTo(description);
+
+        assertThat("Should format 30 seconds by default", description.toString(), equalTo("30 seconds"));
+    }
+
+    @Test
+    public void shouldReturnMinutesInDescription() throws Exception {
+        StringDescription description = new StringDescription();
+        TimeoutWaiter.timeoutHasExpired(TimeUnit.MINUTES.toMillis(2)).describeTo(description);
+
+        assertThat("Should format millis as minutes if can", description.toString(), equalTo("2 minutes"));
+    }
+}


### PR DESCRIPTION
for example: `<120 000L> milliseconds` now became as `2 minutes`
