### PR TITLE
add - wd matchers

### DIFF
--- a/webdriver-matchers/README.md
+++ b/webdriver-matchers/README.md
@@ -54,4 +54,6 @@ List of all matchers in module.
 
 ## WebDriver Matchers
 
-... *(will be soon)*
+- `HasCookieMatcher#hasCookie(String)` - matches if WebDriver has such cookie
+- `CanFindElementMatcher#canFindElement(By)` - matches id WD can find element by `By` selector
+- `HasTextMatcher#textOnCurrentPage(Matcher<String>)` & `HasTextMatcher#textOnCurrentPageContains(String)` - matches if page source matches text matcher or contains text

--- a/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/CanFindElementMatcher.java
+++ b/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/CanFindElementMatcher.java
@@ -1,0 +1,42 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+
+public class CanFindElementMatcher extends TypeSafeMatcher<WebDriver> {
+    private By by;
+
+    protected CanFindElementMatcher(By by) {
+        this.by = by;
+    }
+
+    @Override
+    protected boolean matchesSafely(WebDriver wd) {
+        try {
+            wd.findElement(by);
+            return true;
+        } catch (NoSuchElementException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("element on page ").appendValue(by);
+    }
+
+    @Override
+    protected void describeMismatchSafely(WebDriver wd, Description mismatchDescription) {
+        mismatchDescription.appendText("no any element with selector ").appendValue(by).appendText(" found");
+    }
+
+    @Factory
+    public static Matcher<WebDriver> canFindElement(By by) {
+        return new CanFindElementMatcher(by);
+    }
+}

--- a/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/HasCookieMatcher.java
+++ b/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/HasCookieMatcher.java
@@ -1,0 +1,49 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class HasCookieMatcher extends TypeSafeMatcher<WebDriver> {
+    private String name;
+
+    protected HasCookieMatcher(String name) {
+        this.name = name;
+    }
+
+    @Override
+    protected boolean matchesSafely(WebDriver wDriver) {
+        try {
+            wDriver.manage().getCookieNamed(name).toString();
+            return true;
+        } catch (NullPointerException npe) {
+            return false;
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("cookie named ").appendValue(name);
+    }
+
+    @Override
+    protected void describeMismatchSafely(WebDriver item, Description mismatchDescription) {
+        mismatchDescription.appendText("was only ");
+        List<String> cookNames = new LinkedList<>();
+        for (Cookie cook : item.manage().getCookies()) {
+           cookNames.add(cook.getName());
+        }
+        mismatchDescription.appendValueList("[", ", ", "]", cookNames);
+    }
+
+    @Factory
+    public static Matcher<WebDriver> hasCookie(String name) {
+        return new HasCookieMatcher(name);
+    }
+}

--- a/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/HasTextMatcher.java
+++ b/webdriver-matchers/src/main/java/ru/yandex/qatools/matchers/webdriver/driver/HasTextMatcher.java
@@ -1,0 +1,41 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.openqa.selenium.WebDriver;
+
+public class HasTextMatcher extends TypeSafeMatcher<WebDriver> {
+    private Matcher<String> matcher;
+
+    protected HasTextMatcher(Matcher<String> matcher) {
+        this.matcher = matcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(WebDriver wd) {
+        return matcher.matches(wd.getPageSource());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("webdriver has page with text ").appendDescriptionOf(matcher);
+    }
+
+    @Override
+    protected void describeMismatchSafely(WebDriver item, Description mismatchDescription) {
+        matcher.describeMismatch(item.getPageSource(), mismatchDescription);
+    }
+
+    @Factory
+    public static Matcher<WebDriver> textOnCurrentPageContains(String text) {
+        return textOnCurrentPage(CoreMatchers.containsString(text));
+    }
+
+    @Factory
+    public static Matcher<WebDriver> textOnCurrentPage(Matcher<String> text) {
+        return new HasTextMatcher(text);
+    }
+}

--- a/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/CanFindElementMatcherTest.java
+++ b/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/CanFindElementMatcherTest.java
@@ -1,0 +1,38 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ru.yandex.qatools.matchers.webdriver.driver.CanFindElementMatcher.canFindElement;
+
+public class CanFindElementMatcherTest {
+
+    public static final By XPATH_EXISTS = By.xpath("//a");
+    public static final By XPATH_NOT_EXISTS = By.xpath("//aa");
+
+    @Test
+    public void worksPositive() {
+        WebDriver driver = mock(WebDriver.class);
+        WebElement element = mock(WebElement.class);
+
+        when(driver.findElement(XPATH_EXISTS)).thenReturn(element);
+
+        assertThat("Element should be found", driver, canFindElement(XPATH_EXISTS));
+    }
+
+    @Test
+    public void worksNegative() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.findElement(XPATH_NOT_EXISTS)).thenThrow(new NoSuchElementException(""));
+
+        assertThat("Element should not be found",
+                driver, not(canFindElement(XPATH_NOT_EXISTS)));
+    }
+}

--- a/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/HasCookieMatcherTest.java
+++ b/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/HasCookieMatcherTest.java
@@ -1,0 +1,42 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.junit.Test;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriver.Options;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ru.yandex.qatools.matchers.webdriver.driver.HasCookieMatcher.hasCookie;
+
+public class HasCookieMatcherTest {
+    private static final String cookieName = "Cookie";
+
+    @Test
+    public void shouldFindExistingCookie() {
+        WebDriver driver = mock(WebDriver.class);
+        Options options = mock(Options.class);
+        Cookie cookie = new Cookie(cookieName, "oki-doki");
+
+
+        when(driver.manage()).thenReturn(options);
+        when(options.getCookieNamed(eq(cookieName))).thenReturn(cookie);
+
+        assertThat("Cookie not found!", driver, hasCookie(cookieName));
+    }
+
+    @Test
+    public void shouldNotFindUnexistingCookie() {
+        final WebDriver driver = mock(WebDriver.class);
+        Options options = mock(Options.class);
+
+        when(driver.manage()).thenReturn(options);
+        when(options.getCookieNamed(eq(cookieName))).thenReturn(null);
+
+
+        assertThat("Cook should not be found", driver, not(hasCookie(cookieName)));
+    }
+}

--- a/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/HasTextMatcherTest.java
+++ b/webdriver-matchers/src/test/java/ru/yandex/qatools/matchers/webdriver/driver/HasTextMatcherTest.java
@@ -1,0 +1,35 @@
+package ru.yandex.qatools.matchers.webdriver.driver;
+
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ru.yandex.qatools.matchers.webdriver.driver.HasTextMatcher.textOnCurrentPageContains;
+
+public class HasTextMatcherTest {
+
+    public static final String HTML_BODY = "Some html body texting form";
+    public static final String TEXT_PART = "text";
+    public static final String ANOTHER_HTML_BODY = "Some html body tex";
+
+    @Test
+    public void worksPositive() {
+        WebDriver driver = mock(WebDriver.class);
+
+        when(driver.getPageSource()).thenReturn(HTML_BODY);
+
+
+        assertThat("Text should be found", driver, textOnCurrentPageContains(TEXT_PART));
+    }
+
+    @Test
+    public void worksNegative() {
+        final WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn(ANOTHER_HTML_BODY);
+
+        assertThat("Should not found text", driver, not(textOnCurrentPageContains(TEXT_PART)));
+    }
+}


### PR DESCRIPTION
- `HasCookieMatcher#hasCookie(String)` - matches if WebDriver has such cookie
- `CanFindElementMatcher#canFindElement(By)` - matches id WD can find element by `By` selector
- `HasTextMatcher#textOnCurrentPage(Matcher<String>)` & `HasTextMatcher#textOnCurrentPageContains(String)` - matches if page source matches text matcher or contains text